### PR TITLE
Add deployment target macOS 10.15

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-# platform :ios, '9.0'
+platform :osx, '10.15'
 
 target 'Converter' do
   # Comment the next line if you don't want to use dynamic frameworks


### PR DESCRIPTION
Left blank, CocoaPods will default to building for the latest available deployment target.

- Converter.app deployment set to `10.15` ([Quick Preview](https://user-images.githubusercontent.com/1476332/185808048-67323f39-65d0-4376-b313-2c30222b29b6.png))
- CocoaPods deployment defaulting to `12.3` ([Quick Preview](https://user-images.githubusercontent.com/1476332/185808050-1a171a0c-7001-4b7d-afb1-0de88f90746a.png))

Might be worth testing to ensure that there are no issues with the build process!

`pod install`
`pod update`