### PR TITLE
Refactor hardcoded formats

### DIFF
--- a/Converter/ViewController.swift
+++ b/Converter/ViewController.swift
@@ -187,7 +187,7 @@ class ViewController: NSViewController, DragDropViewDelegate {
     // Handler function
     userDidSelectFormat(userSelectedFormatType)
   }
-  var userSelectedFormat = "MP4"
+  var userSelectedFormat = VideoFormat.mp4.dropdownTitle
   var userSelectedFormatType: VideoFormat = .mp4
   
   @IBAction func clickConvert(_ sender: Any) {


### PR DESCRIPTION
`func getDropdownTitles()` now gets its array of titles directly from VideoFormat 832c9bd8af08294d98530c8c00bd132c62a5cb47
- Replaced hardcoded values with `VideoFormat.allCases.dropdownTitle`
- Removed TODO due to new use case
  - ie. MP4 → MP4 with codec conversion x265 → x264
  - https://github.com/revblaze/Converter/pull/9/commits/0434241777cfcf25f80bbc54e41df173e87846ea#r952948519

`func getFormat(String)` now checks equality against VideoFormat cases  0434241777cfcf25f80bbc54e41df173e87846ea
- `getDropdownTitles()` gets values from `VideoFormat.dropdownTitle`
- `getFormat(String)` gets called on dropdownTitle selection
  - where input String is always from selection `VideoFormat.dropdownTitle`