### PR TITLE
feat: update EST based on time remaining

### DIFF
--- a/Converter/ViewController.swift
+++ b/Converter/ViewController.swift
@@ -133,7 +133,12 @@ class ViewController: NSViewController, DragDropViewDelegate {
   func updateTimeRemaining(_ remainingInSeconds: Double) {
     let seconds = Int(remainingInSeconds)
     let (h, m, s) = (seconds / 3600, (seconds % 3600) / 60, (seconds % 3600) % 60)
-    estimatedTimeText.stringValue = "\(h)h \(m)m \(s)s"
+    
+    if h > 0 {
+      estimatedTimeText.stringValue = "\(h)h \(m)m"
+    } else {
+      estimatedTimeText.stringValue = "\(m)m \(s)s"
+    }
   }
   
   func selectOutputFileUrl(format: VideoFormat) {


### PR DESCRIPTION
```
if timeRemaining ≥ 1 hour {
  display (hours, minutes) remaining
else {
  display (minutes, seconds) remaining
```

### Case 1: Estimated time remaining ≥ 1hr
- When the `estimated time remaining > 60 minutes` (let alone `>20`), the number of seconds remaining is noticeably more volatile than the hour(s) or minute(s) remaining; ie.
  1. Input large/long video file (tested 800MB MKV to WEBM with 60-minute runtime)
  2. Convert to different codec (where `conversion time > 60 minutes`)
  3. Watch as the `seconds` erratically range anywhere from 0-60 at any given time
- No consistency of seconds-countdown, as even minutes-remaining still varies between 1-5 at this point in the conversion process

### Case 2: Estimated time remaining < 1hr
- When the `estimated time remaining < 60 minutes`, there is no need to show hours remaining
- However, counting-down of the seconds become more accurate and meaningful at this point in the conversion process
- Seconds are still inconsistent up until ~2-4 minutes remaining, but not as wildly in comparison to Case 1 (nor as meaningless)

![1_Before-After_800MB](https://user-images.githubusercontent.com/1476332/186236282-19b36e03-370d-426f-a799-6bce22a7b47b.jpg)
![2_Before-After_60MB](https://user-images.githubusercontent.com/1476332/186236287-d51a575d-69ba-4e3f-b2e5-e7b95de3a7c5.jpg)

