### PR TITLE
feat: add conversionDidComplete alert prompt

### DIFF
--- a/Converter/Views/Alerts/ConversionDidComplete.swift
+++ b/Converter/Views/Alerts/ConversionDidComplete.swift
@@ -1,0 +1,50 @@
+//
+//  ConversionDidComplete.swift
+//  Converter
+//
+//  Created by Justin Bush on 8/23/22.
+//
+
+import Cocoa
+
+extension ViewController {
+  
+  /// Alert user of successful conversion output and display "Reveal in Finder" option
+  func alertConversionDidComplete(withOutputPath: URL) {
+    let a = NSAlert()
+    a.messageText = "Conversion Complete"
+    a.informativeText = "Your video file has been converted successfully!"
+    a.addButton(withTitle: "OK")
+    a.addButton(withTitle: "Reveal in Finder")
+    a.alertStyle = NSAlert.Style.informational
+    
+    a.beginSheetModal(for: self.view.window!, completionHandler: { (modalResponse) -> Void in
+      if modalResponse == NSApplication.ModalResponse.alertFirstButtonReturn {
+        print("User did acknowledge successful file conversion")
+      }
+      if modalResponse == NSApplication.ModalResponse.alertSecondButtonReturn {
+        print("User did select: Reveal in Finder")
+        self.showInFinder(url: withOutputPath)
+      }
+    })
+  }
+  
+  /// Open Finder with selected file at designated `url`
+  func showInFinder(url: URL?) {
+    guard let url = url else { return }
+    
+    if url.isDirectory {
+      NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: url.path)
+    } else {
+      NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+  }
+  
+}
+
+extension URL {
+  /// Returns true if URL in question is a valid directory
+  var isDirectory: Bool {
+    return (try? resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+  }
+}


### PR DESCRIPTION
Prompt user with an alert upon successfully completing the conversion process.

- Provide "Reveal in Finder" option using `outputFileUrl`

<img width="774" alt="Screen Shot 2022-08-23 at 1 40 04 PM" src="https://user-images.githubusercontent.com/1476332/186251344-b4a56945-953f-4b7e-b2b4-b53ce64000bd.png">

Note: Although located in `/Views/Alerts/ConversionDidComplete.swift`, these functions act as an extension to `ViewController`. Meaning, the functionality was added within the scope of `ViewController.swift` – and is fully accessible from anywhere within the ViewController – but is added to an external file and thus doesn't affect the ViewController source file.