### PR TITLE
refactor: case for seconds-remaining and complete

### DIFF
--- a/Converter/ViewController.swift
+++ b/Converter/ViewController.swift
@@ -138,6 +138,8 @@ class ViewController: NSViewController, DragDropViewDelegate {
     let seconds = Int(remainingInSeconds)
     let (h, m, s) = (seconds / 3600, (seconds % 3600) / 60, (seconds % 3600) % 60)
     
+    // TODO: Implement "Finishing up..." phase before "Done!"
+    // This TODO may not be necessary if we implement progress Timer properly
     if h > 0 {
       estimatedTimeText.stringValue = "\(h)h \(m)m"
     } else if m > 0 {


### PR DESCRIPTION
Additional logic for handling estimated time remaining:

**Before**
```
if h > 0 {
  show hours, minutes
else {
  show minutes, seconds
```

**After**
```
if h > 0 {
  show hours, minutes
else if m > 0 {
  show minutes, seconds
else if s > 0 {
  show seconds
else {
  show "Done!"
```

The progress bar seems to stop at around 95-98% completion for 10-20s, and will then actually complete. Thus, at some point, we'll need to implement a case for "Finishing up..." in between the `show seconds` and `show "Done!"`