### PR TITLE
refactor: hide helpInfo upon clicking sender button while open

### DIFF
--- a/Converter/ViewController.swift
+++ b/Converter/ViewController.swift
@@ -359,10 +359,14 @@ class ViewController: NSViewController, NSPopoverDelegate, DragDropViewDelegate 
   }()
   /// Displays `helpInfoPopover` to minY-position of object sender: `(?)`
   @IBAction func showHelpInfoPopover(sender: NSButton) {
-    let positioningView = sender
-    let positioningRect = NSZeroRect
-    let preferredEdge = NSRectEdge.minY
-    helpInfoPopover.show(relativeTo: positioningRect, of: positioningView, preferredEdge: preferredEdge)
+    if (helpInfoPopover.isShown) {
+      hidePopover(helpInfoPopover)
+    } else {
+      let positioningView = sender
+      let positioningRect = NSZeroRect
+      let preferredEdge = NSRectEdge.minY
+      helpInfoPopover.show(relativeTo: positioningRect, of: positioningView, preferredEdge: preferredEdge)
+    }
   }
   /// Hide specific NSPopover object
   func hidePopover(_ popover: NSPopover) {


### PR DESCRIPTION
Forgot to implement expected functionality: hide on click-action while `popover.isShown`

https://user-images.githubusercontent.com/1476332/187517440-242b99f7-f995-4761-941a-b02a5a662928.mov

