### PR TITLE
fix: open closed window on input

### DIFF
--- a/Converter/AppDelegate.swift
+++ b/Converter/AppDelegate.swift
@@ -52,6 +52,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     if mainViewHasAppeared {
       let viewController = self.mainWindow.contentViewController as? ViewController
       viewController?.dragDropViewDidReceive(fileUrl: filename)
+      mainWindow.makeKeyAndOrderFront(self)
     } else {
       // Otherwise, set String flag for opening once mainView hasAppeared
       openAppWithFilePath = filename


### PR DESCRIPTION
Not sure how to link an issue to a new branch/PR: https://linear.app/video-converter/issue/VID-19/show-window-on-input-if-window-is-closedminimized

<img width="1392" alt="Screen Shot 2022-09-20 at 12 44 41 PM" src="https://user-images.githubusercontent.com/1476332/191339177-64756707-6cd8-4996-9483-010d71d6c3f2.png">

### Fix Summary

Under the condition that the user has either closed or minimized the main Converter window, the window will now reappear upon importing a new video file by either:

- Dragging and dropping the file onto the Converter app icon
- In Finder, selecting `Open With → Converter.app`

https://user-images.githubusercontent.com/1476332/191339987-2bf73958-2cec-4b14-8f51-f468ea83f2d5.mov