### PR TITLE
feat: executeasync ffprobe

### DIFF
--- a/Converter/Constants.swift
+++ b/Converter/Constants.swift
@@ -11,5 +11,7 @@ struct Constants {
   static let progressUpdateInterval = 0.5
   static let estimatedTimeLabelText = "Estimated time remaining"
   static let estimatingTimeLabelText = "Estimating time remaining..."
+  static let processingInputFileLabelText = "Processing..."
+  static let beginConversionLabelText = "Click convert to begin"
 }
 

--- a/Converter/Conversion.swift
+++ b/Converter/Conversion.swift
@@ -256,11 +256,13 @@ func runFfmpegCommand(command: String, onDone: @escaping (_: FFmpegSession?) -> 
   return session!
 }
 
-func getAllVideoProperties(inputFilePath: String) -> Video {
-  let session = FFprobeKit.execute("-loglevel error -count_packets -show_entries stream:format \"\(inputFilePath)\"")
-  let logs = session?.getAllLogsAsString()!.trimmingCharacters(in: .whitespacesAndNewlines)
-
-  return buildVideo(withFfprobeOutput: logs!, inputFilePath: inputFilePath)
+func getAllVideoProperties(inputFilePath: String, onDone: @escaping (_: Video) -> Void) -> Void {
+  FFprobeKit.executeAsync("-loglevel error -count_packets -show_entries stream:format \"\(inputFilePath)\"") { session in
+    let logs = session?.getAllLogsAsString()!.trimmingCharacters(in: .whitespacesAndNewlines)
+    
+    let video = buildVideo(withFfprobeOutput: logs!, inputFilePath: inputFilePath)
+    onDone(video)
+  }
 }
 
 // This uses the same command as getAllVideoProperties but we leave out the loglevel field to include additional metadata


### PR DESCRIPTION
This PR switches our FFPROBE command to async.

The UI feels a bit off to me... I think its because the "Estimated time" text is changing a bit too much. What're your thoughts @revblaze ?  The first recording is for a larger video (close to 1GB), the second video is a much smaller video (10MB).


https://user-images.githubusercontent.com/26126685/193299857-8081176d-e6d4-4377-8ac7-9527a455ee66.mov



https://user-images.githubusercontent.com/26126685/193299866-c4c6e22c-88f5-49e4-8d52-20b96332e492.mov



