### PR TITLE
fix: show clear button on warning style

### DIFF
--- a/Converter/ViewController.swift
+++ b/Converter/ViewController.swift
@@ -334,6 +334,10 @@ class ViewController: NSViewController, NSPopoverDelegate, DragDropViewDelegate 
   }
   /// Sets the dragDropBox image view (ie. Set red warning box with `.warning`)
   func updateDragDropView(_ forType: DragDropBox.Style) {
+    if forType == .warning {
+      displayClearButton(.show)
+    }
+    
     if premiumViewIsExpanded {
       dragDropBackgroundImageView.image = forType.backgroundImageWide
     } else {
@@ -351,14 +355,12 @@ class ViewController: NSViewController, NSPopoverDelegate, DragDropViewDelegate 
     clearInputVideos()
     updateDragDrop(subtitle: "Unsupported file type", withStyle: .warning)
     showSupportedFormatsPopover()
-    displayClearButton(.show)
   }
   /// Sets DragDropBox for error state: Corrupted video file
   func showCorruptVideoFileBox() {
     Logger.debug("Displaying corrupt file error")
     clearInputVideos()
     updateDragDrop(subtitle: "Video file is corrupt", withStyle: .warning)
-    displayClearButton(.show)
   }
   
   /// Sets DragDropBox for error state: Too many input videos
@@ -366,7 +368,6 @@ class ViewController: NSViewController, NSPopoverDelegate, DragDropViewDelegate 
     Logger.debug("Displaying too many videos error")
     clearInputVideos()
     updateDragDrop(subtitle: "Too many videos selected (maximum \(Constants.fileCountLimit))", withStyle: .warning)
-    displayClearButton(.show)
   }
   
   /// Returns VideoFormat type upon user dropdown selection (ie. `.mp4`)


### PR DESCRIPTION
**Caution:** This commit is based on an older pull of [fvirga/directory-input-file-support](https://github.com/inter-ops/Converter/tree/fvirga/directory-input-file-support)!