### PR TITLE
feat: specify encoder

### DIFF
--- a/Converter/Conversion.swift
+++ b/Converter/Conversion.swift
@@ -330,7 +330,7 @@ func getVideoCommandForGif(inputVideo: Video, outputQuality: VideoQuality) -> St
   // TODO: There is still a slight stutter with certain output videos. This seems to improve with higher FPS but not resolve completely.
   // TODO: There is a slight delay with progress as the palette file needs to be created. Look into ways to estimate this, or may want to add an arbitrary delay based on file size or format. This delay is especially long for x265. Didnt find much online, so should ask stackoverflow. At the minimum, we should make it more clear that we are estimating conversion time during this period (since we show no progress bar).
   // NOTE: If color is an issue, use "palettegen=stats_mode=single" and "paletteuse=new=1"
-  return "-vf \"fps=\(fps),scale=0:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse\" -loop 0"
+  return "-c:v gif -vf \"fps=\(fps),scale=0:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse\" -loop 0"
 }
 
 /// Get the video portion of the ffmpeg command.


### PR DESCRIPTION
This PR resolves the latest email error report we received (I hope). For some reason, ffmpeg couldnt detect the default encoder to use for GIF in their case. This change explicitly defines it for gif conversions.

This doesnt actually change anything, it just ensures that we are explicit about the video codec to use (instead of letting ffmpeg determine it to be `gif`)