### PR TITLE
refactor: rename all "UI" to "Ui"

### DIFF
--- a/Converter/AppMenu/AppMenu+Debug.swift
+++ b/Converter/AppMenu/AppMenu+Debug.swift
@@ -35,17 +35,17 @@ extension AppDelegate {
   
   @IBAction func enableViewControllerUI(_ sender: Any) {
     let viewController = mainWindow.contentViewController as? ViewController
-    viewController?.enableUI()
+    viewController?.enableUi()
   }
   
   @IBAction func disableViewControllerUI(_ sender: Any) {
     let viewController = mainWindow.contentViewController as? ViewController
-    viewController?.disableUI()
+    viewController?.disableUi()
   }
   
   @IBAction func disableViewControllerUIWithAnimation(_ sender: Any) {
     let viewController = mainWindow.contentViewController as? ViewController
-    viewController?.disableUI(withLoaderAnimation: true)
+    viewController?.disableUi(withLoaderAnimation: true)
   }
   
   // MARK: - StoreKit

--- a/Converter/StoreKit/Receipt/ViewController+VersionCheck.swift
+++ b/Converter/StoreKit/Receipt/ViewController+VersionCheck.swift
@@ -71,12 +71,12 @@ extension ViewController {
   }
   
   func disableUiAndShowLatestVersionAlert() {
-    disableUI()
+    disableUi()
     showLatestVersionAlert()
   }
   
   func disableUiAndShowConnectionRequiredAlert() {
-    disableUI()
+    disableUi()
     showConnectionRequiredAlert()
   }
   

--- a/Converter/ViewController.swift
+++ b/Converter/ViewController.swift
@@ -149,13 +149,13 @@ class ViewController: NSViewController, NSPopoverDelegate, DragDropViewDelegate 
     // If AppDelegate has already initated queue session, ignore additional requests
     if appDelegate.didDispatchFileQueue == false {
       appDelegate.didDispatchFileQueue = true   // Is first session call, switch flag
-      disableUI(withLoaderAnimation: true)      // Disable UI with loader animation
+      disableUi(withLoaderAnimation: true)      // Disable UI with loader animation
       // After 0.3s has elapsed, initate import of file queue
       DispatchQueue.main.asyncAfter(deadline: .now() + Constants.inputFileFromSystemBufferDelay) {
         self.dragDropViewDidReceive(filePaths: self.appDelegate.openAppWithFilePaths)
         self.appDelegate.openAppWithFilePaths = []    // Empty openAppWithFilePaths
         self.appDelegate.didDispatchFileQueue = false // Enable UI
-        self.enableUI()
+        self.enableUi()
       }
     }
   }
@@ -568,7 +568,7 @@ class ViewController: NSViewController, NSPopoverDelegate, DragDropViewDelegate 
       userDidClickStop()
       actionButton.title = "Convert"
       currentStatus = .ready
-      enableUI()
+      enableUi()
     }
   }
   
@@ -576,7 +576,7 @@ class ViewController: NSViewController, NSPopoverDelegate, DragDropViewDelegate 
   func resetActionButton() {
     actionButton.title = "Convert"
     currentStatus = .ready
-    enableUI()
+    enableUi()
   }
   
   /// Called when the user clicks "Stop" upon a conversion-in-progress

--- a/Converter/Views/ProcessHandler/EnableDisableUI.swift
+++ b/Converter/Views/ProcessHandler/EnableDisableUI.swift
@@ -10,14 +10,14 @@ import Cocoa
 extension ViewController {
   /// Enable all free UI elements, with Premium elements dependent on `userDidPurchasePremium`.
   /// Additionally, hide any process loaders and stop ongoing animations.
-  func enableUI() {
+  func enableUi() {
     enableAllOnScreenElements()   // Set isEnabled state of individual UI elements
     enableDragDropView()          // Custom DragDropView handling for enabled state
     hideProcessLoaderAnimation()  // Hide processLoader and stop animation
   }
   /// Disable all UI elements. Show process loader with animation state.
   /// Call `disableUI(withLoaderAnimation: true)` to also show the process loader animation.
-  func disableUI(withLoaderAnimation: Bool = false) {
+  func disableUi(withLoaderAnimation: Bool = false) {
     disableAllOnScreenElements()  // Set isEnabled state of individual UI elements
     disableDragDropView()         // Custom DragDropView handling for disabled state
     // Show process loader by default, with option to disable without animation


### PR DESCRIPTION
Match naming scheme for Ui functions to match rest of application.

`UI` → `Ui`