### PR TITLE
fix: only select first stream

### DIFF
--- a/Converter/Conversion.swift
+++ b/Converter/Conversion.swift
@@ -553,7 +553,7 @@ func getFfmpegCommand(inputVideo: Video, outputVideoCodec: VideoCodec, outputVid
   
   // We currently map all audio and video streams, but subtitle stream mapping is handled by getSubtitleConversionCommand. Once we support
   // converting more than one audio and video stream, the mapping should be moved to getVideoConversionCommand and getAudioConversionCommand
-  let command = "-hide_banner -y -i \"\(inputVideo.filePath)\" -map 0:v? \(videoCommand) \(audioCommand) \(subtitleCommand) \"\(inputVideo.outputFilePath!)\""
+  let command = "-hide_banner -y -i \"\(inputVideo.filePath)\" -map 0:v:0? \(videoCommand) \(audioCommand) \(subtitleCommand) \"\(inputVideo.outputFilePath!)\""
   
   return command
 }

--- a/Converter/VideoFormat/VideoCodec.swift
+++ b/Converter/VideoFormat/VideoCodec.swift
@@ -17,10 +17,10 @@ enum VideoCodec: String, CaseIterable {
     case .vp9: return "VP9"
     case .mpeg4: return "MPEG-4"
     case .gif: return "GIF"
+    case .prores: return "Apple ProRes"
     // Will not appear in codec dropdown
     case .mpeg1video: return "MPEG-1"
     case .mpeg2video: return "MPEG-2"
-    case .prores: return "Apple ProRes"
     case .unknown: return "Unknown"
     }
   }


### PR DESCRIPTION
This fixes the Alien video bug, by only selecting the first video stream instead of all of them.